### PR TITLE
Use tm element instead of ™.

### DIFF
--- a/topics/links/lc_xrefs.dita
+++ b/topics/links/lc_xrefs.dita
@@ -25,11 +25,11 @@
                     here:<pre>&lt;xref href="http://www.scriptorium.com" scope="external" format="html"/></pre><note>For
                     links to a PDF file, use @format = "pdf".</note></p>
             <p>Technically, it is possible to use &lt;xref> to link from one topic to another. This
-                inline linking is a Bad Idea™ because you have to create and maintain the link
-                manually. You must specify what you are linking to. When you set up the
-                cross-reference, you have the source and target topics in your map file. But if you
-                reuse the source topic in another map that does not include the target topic, you
-                will get a broken link in the output generated from that map, and you may not be
+                inline linking is a <tm tmtype="tm">Bad Idea</tm> because you have to create and
+                maintain the link manually. You must specify what you are linking to. When you set
+                up the cross-reference, you have the source and target topics in your map file. But
+                if you reuse the source topic in another map that does not include the target topic,
+                you will get a broken link in the output generated from that map, and you may not be
                 notified about the problem.</p>
     </lcInstruction>
     </learningContentbody>

--- a/topics/tables/lc_best_practices.dita
+++ b/topics/tables/lc_best_practices.dita
@@ -6,7 +6,7 @@
     <learningContentbody>
         <lcInstruction><p>Always wrap content in the table in &lt;p> tags. Forgetting this can
                 result in the content of the table to format in unexpected ways. </p><p>While the
-                DITA specification allows you to nest tables, it's a Bad Idea™.
+                DITA specification allows you to nest tables, it's a <tm tmtype="tm">Bad Idea</tm>.
                 </p><p>Whenever possible, consider organizing the content in your table to include
                 more rows instead of more columns. When you send the content to an output,
                 pagination issues can make many columns appear in unexpected ways. </p><p>In many


### PR DESCRIPTION
Just in case you want this fix - the default Schematron validation from oXygen mentiones this with the message:
"It's preferable to use tm element instead of ™ character." 
and points to:
http://docs.oasis-open.org/dita/v1.1/OS/langspec/langref/tm.html
