### PR TITLE
Make this consistent with 2 other usages of note

### DIFF
--- a/topics/lc_specialization.dita
+++ b/topics/lc_specialization.dita
@@ -30,10 +30,10 @@
                             <li><pre>&lt;codeblock type="php"></pre></li>
                         </ul></li>
                 </ul></p>
-        <note type="caution">    <p>Be careful with specialization. When you specialize, you make tags more specific, but
-                specialization adds to the cost of implementation. You must balance the value gained
-                from specialization against the cost of implementing and maintaining
-                specializations.</p></note>
+        <note type="caution">Be careful with specialization. When you specialize, you make tags more
+                specific, but specialization adds to the cost of implementation. You must balance
+                the value gained from specialization against the cost of implementing and
+                maintaining specializations.</note>
        </lcInstruction>
     </learningContentbody>
 </learningContent>


### PR DESCRIPTION
Also according to the DITA Style Guide: http://www.oxygenxml.com/dita/styleguide/webhelp-feedback/index.html#Artefact/Syntax_and_Markup/c_Paragraphs_within_Notes.html

Please remove the "p" element and place its text directly in the note. If there is just one block of text in the note, then the note should be left as string-only. This stores the minimum of mark-up, and simplifies the processed output. If there are multiple blocks in the note, then paragraphs, lists (or other block elements) should be used.
(detected by Schematron validation that implements this style guide rule)
