### PR TITLE
Fix duplicate ID values for different topics

### DIFF
--- a/assessments/links/lca_conref.dita
+++ b/assessments/links/lca_conref.dita
@@ -3,7 +3,7 @@
      github.com. See the accompanying LICENSE file for
      applicable licenses.-->
 <!DOCTYPE learningAssessment PUBLIC "-//OASIS//DTD DITA Learning Assessment//EN" "learningAssessment.dtd">
-<learningAssessment id="assessment_f33_1kp_wr">
+<learningAssessment id="assessment_f33_1kp_wr4">
  <title></title>
  <prolog>
   <author>Sharon Burton</author>

--- a/assessments/links/lca_inline.dita
+++ b/assessments/links/lca_inline.dita
@@ -3,7 +3,7 @@
      github.com. See the accompanying LICENSE file for
      applicable licenses.-->
 <!DOCTYPE learningAssessment PUBLIC "-//OASIS//DTD DITA Learning Assessment//EN" "learningAssessment.dtd">
-<learningAssessment id="assessment_f33_1kp_wr">
+<learningAssessment id="assessment_f33_1kp_wr5">
  <title></title>
  <prolog>
   <author>Sharon Burton</author>

--- a/assessments/links/lca_linkcode.dita
+++ b/assessments/links/lca_linkcode.dita
@@ -3,7 +3,7 @@
      github.com. See the accompanying LICENSE file for
      applicable licenses.-->
 <!DOCTYPE learningAssessment PUBLIC "-//OASIS//DTD DITA Learning Assessment//EN" "learningAssessment.dtd">
-<learningAssessment id="assessment_f33_1kp_wr">
+<learningAssessment id="assessment_f33_1kp_wr6">
  <title></title>
  <prolog>
   <author>Sharon Burton</author>

--- a/assessments/links/lca_maps.dita
+++ b/assessments/links/lca_maps.dita
@@ -3,7 +3,7 @@
      github.com. See the accompanying LICENSE file for
      applicable licenses.-->
 <!DOCTYPE learningAssessment PUBLIC "-//OASIS//DTD DITA Learning Assessment//EN" "learningAssessment.dtd">
-<learningAssessment id="assessment_f33_1kp_wr">
+<learningAssessment id="assessment_f33_1kp_wrb">
  <title></title>
  <prolog>
   <author href="http://www.scriptorium.com" scope="external" format="html">Sarah O’Keefe, Scriptorium</author>

--- a/assessments/links/lca_relationships.dita
+++ b/assessments/links/lca_relationships.dita
@@ -3,7 +3,7 @@
      github.com. See the accompanying LICENSE file for
      applicable licenses.-->
 <!DOCTYPE learningAssessment PUBLIC "-//OASIS//DTD DITA Learning Assessment//EN" "learningAssessment.dtd">
-<learningAssessment id="assessment_f33_1kp_wr">
+<learningAssessment id="assessment_f33_1kp_wr2">
  <title></title>
  <prolog>
   <author>Sharon Burton</author>

--- a/assessments/links/lca_reltable.dita
+++ b/assessments/links/lca_reltable.dita
@@ -3,7 +3,7 @@
      github.com. See the accompanying LICENSE file for
      applicable licenses.-->
 <!DOCTYPE learningAssessment PUBLIC "-//OASIS//DTD DITA Learning Assessment//EN" "learningAssessment.dtd">
-<learningAssessment id="assessment_f33_1kp_wr">
+<learningAssessment id="assessment_f33_1kp_wra">
  <title/>
  <prolog>
   <author>Sharon Burton</author>

--- a/assessments/links/lca_reltable2.dita
+++ b/assessments/links/lca_reltable2.dita
@@ -3,7 +3,7 @@
      github.com. See the accompanying LICENSE file for
      applicable licenses.-->
 <!DOCTYPE learningAssessment PUBLIC "-//OASIS//DTD DITA Learning Assessment//EN" "learningAssessment.dtd">
-<learningAssessment id="assessment_f33_1kp_wr">
+<learningAssessment id="assessment_f33_1kp_wr8">
  <title></title>
  <prolog>
   <author>Sharon Burton</author>

--- a/assessments/links/lca_reltablemap.dita
+++ b/assessments/links/lca_reltablemap.dita
@@ -3,7 +3,7 @@
      github.com. See the accompanying LICENSE file for
      applicable licenses.-->
 <!DOCTYPE learningAssessment PUBLIC "-//OASIS//DTD DITA Learning Assessment//EN" "learningAssessment.dtd">
-<learningAssessment id="assessment_f33_1kp_wr">
+<learningAssessment id="assessment_f33_1kp_wr9">
  <title></title>
  <prolog>
   <author>Sharon Burton</author>

--- a/assessments/links/lca_weblink.dita
+++ b/assessments/links/lca_weblink.dita
@@ -3,7 +3,7 @@
      github.com. See the accompanying LICENSE file for
      applicable licenses.-->
 <!DOCTYPE learningAssessment PUBLIC "-//OASIS//DTD DITA Learning Assessment//EN" "learningAssessment.dtd">
-<learningAssessment id="assessment_f33_1kp_wr">
+<learningAssessment id="assessment_f33_1kp_wr3">
  <title></title>
  <prolog>
   <author>Sharon Burton</author>

--- a/assessments/links/lca_weblink2.dita
+++ b/assessments/links/lca_weblink2.dita
@@ -3,7 +3,7 @@
      github.com. See the accompanying LICENSE file for
      applicable licenses.-->
 <!DOCTYPE learningAssessment PUBLIC "-//OASIS//DTD DITA Learning Assessment//EN" "learningAssessment.dtd">
-<learningAssessment id="assessment_f33_1kp_wr">
+<learningAssessment id="assessment_f33_1kp_wr7">
  <title></title>
  <prolog>
   <author>Sharon Burton</author>

--- a/assessments/links/lca_xref.dita
+++ b/assessments/links/lca_xref.dita
@@ -3,7 +3,7 @@
      github.com. See the accompanying LICENSE file for
      applicable licenses.-->
 <!DOCTYPE learningAssessment PUBLIC "-//OASIS//DTD DITA Learning Assessment//EN" "learningAssessment.dtd">
-<learningAssessment id="assessment_f33_1kp_wr">
+<learningAssessment id="assessment_f33_1kp_wr1">
  <title></title>
  <prolog>
   <author>Sharon Burton</author>

--- a/assessments/metadata/lca_author.dita
+++ b/assessments/metadata/lca_author.dita
@@ -3,7 +3,7 @@
      github.com. See the accompanying LICENSE file for
      applicable licenses.-->
 <!DOCTYPE learningAssessment PUBLIC "-//OASIS//DTD DITA Learning Assessment//EN" "learningAssessment.dtd">
-<learningAssessment id="assessment_bkn_skb_wr">
+<learningAssessment id="assessment_bkn_skb_wr1">
  <title></title>
  <prolog>
   <author>Sharon Burton</author>

--- a/assessments/metadata/lca_definition.dita
+++ b/assessments/metadata/lca_definition.dita
@@ -3,7 +3,7 @@
      github.com. See the accompanying LICENSE file for
      applicable licenses.-->
 <!DOCTYPE learningAssessment PUBLIC "-//OASIS//DTD DITA Learning Assessment//EN" "learningAssessment.dtd">
-<learningAssessment id="assessment_bkn_skb_wr">
+<learningAssessment id="assessment_bkn_skb_wr2">
  <title></title>
  <prolog>
   <author>Sharon Burton</author>

--- a/assessments/metadata/lca_filters.dita
+++ b/assessments/metadata/lca_filters.dita
@@ -3,7 +3,7 @@
      github.com. See the accompanying LICENSE file for
      applicable licenses.-->
 <!DOCTYPE learningAssessment PUBLIC "-//OASIS//DTD DITA Learning Assessment//EN" "learningAssessment.dtd">
-<learningAssessment id="assessment_bkn_skb_wr">
+<learningAssessment id="assessment_bkn_skb_wr3">
  <title></title>
  <prolog>
   <author>Sharon Burton</author>

--- a/assessments/metadata/lca_filters2.dita
+++ b/assessments/metadata/lca_filters2.dita
@@ -3,7 +3,7 @@
      github.com. See the accompanying LICENSE file for
      applicable licenses.-->
 <!DOCTYPE learningAssessment PUBLIC "-//OASIS//DTD DITA Learning Assessment//EN" "learningAssessment.dtd">
-<learningAssessment id="assessment_bkn_skb_wr">
+<learningAssessment id="assessment_bkn_skb_wr4">
  <title></title>
  <prolog>
   <author>Sharon Burton</author>

--- a/assessments/metadata/lca_md_visible.dita
+++ b/assessments/metadata/lca_md_visible.dita
@@ -3,7 +3,7 @@
      github.com. See the accompanying LICENSE file for
      applicable licenses.-->
 <!DOCTYPE learningAssessment PUBLIC "-//OASIS//DTD DITA Learning Assessment//EN" "learningAssessment.dtd">
-<learningAssessment id="assessment_bkn_skb_wr">
+<learningAssessment id="assessment_bkn_skb_wr5">
  <title></title>
  <prolog>
   <author>Sharon Burton</author>

--- a/assessments/metadata/lca_meaning.dita
+++ b/assessments/metadata/lca_meaning.dita
@@ -3,7 +3,7 @@
      github.com. See the accompanying LICENSE file for
      applicable licenses.-->
 <!DOCTYPE learningAssessment PUBLIC "-//OASIS//DTD DITA Learning Assessment//EN" "learningAssessment.dtd">
-<learningAssessment id="assessment_bkn_skb_wr">
+<learningAssessment id="assessment_bkn_skb_wr6">
  <title></title>
  <prolog>
   <author>Sharon Burton</author>

--- a/assessments/metadata/lca_prolog.dita
+++ b/assessments/metadata/lca_prolog.dita
@@ -3,7 +3,7 @@
      github.com. See the accompanying LICENSE file for
      applicable licenses.-->
 <!DOCTYPE learningAssessment PUBLIC "-//OASIS//DTD DITA Learning Assessment//EN" "learningAssessment.dtd">
-<learningAssessment id="assessment_bkn_skb_wr">
+<learningAssessment id="assessment_bkn_skb_wr7">
  <title></title>
  <prolog>
   <author>Sharon Burton</author>

--- a/assessments/metadata/lca_prologelement.dita
+++ b/assessments/metadata/lca_prologelement.dita
@@ -3,7 +3,7 @@
      github.com. See the accompanying LICENSE file for
      applicable licenses.-->
 <!DOCTYPE learningAssessment PUBLIC "-//OASIS//DTD DITA Learning Assessment//EN" "learningAssessment.dtd">
-<learningAssessment id="assessment_bkn_skb_wr">
+<learningAssessment id="assessment_bkn_skb_wr8">
  <title></title>
  <prolog>
   <author>Sharon Burton</author>

--- a/assessments/metadata/lca_purpose.dita
+++ b/assessments/metadata/lca_purpose.dita
@@ -3,7 +3,7 @@
      github.com. See the accompanying LICENSE file for
      applicable licenses.-->
 <!DOCTYPE learningAssessment PUBLIC "-//OASIS//DTD DITA Learning Assessment//EN" "learningAssessment.dtd">
-<learningAssessment id="assessment_bkn_skb_wr">
+<learningAssessment id="assessment_bkn_skb_wr9">
  <title></title>
  <prolog>
   <author>Sharon Burton</author>

--- a/assessments/metadata/lca_required.dita
+++ b/assessments/metadata/lca_required.dita
@@ -3,7 +3,7 @@
      github.com. See the accompanying LICENSE file for
      applicable licenses.-->
 <!DOCTYPE learningAssessment PUBLIC "-//OASIS//DTD DITA Learning Assessment//EN" "learningAssessment.dtd">
-<learningAssessment id="assessment_bkn_skb_wr">
+<learningAssessment id="assessment_bkn_skb_wra">
  <title></title>
  <prolog>
   <author>Sharon Burton</author>

--- a/assessments/metadata/lca_spec.dita
+++ b/assessments/metadata/lca_spec.dita
@@ -3,7 +3,7 @@
      github.com. See the accompanying LICENSE file for
      applicable licenses.-->
 <!DOCTYPE learningAssessment PUBLIC "-//OASIS//DTD DITA Learning Assessment//EN" "learningAssessment.dtd">
-<learningAssessment id="assessment_bkn_skb_wr">
+<learningAssessment id="assessment_bkn_skb_wrb">
  <title></title>
  <prolog>
   <author>Sharon Burton</author>

--- a/topics/lc_concept.dita
+++ b/topics/lc_concept.dita
@@ -3,7 +3,7 @@
      github.com. See the accompanying LICENSE file for
      applicable licenses.-->
 <!DOCTYPE learningContent PUBLIC "-//OASIS//DTD DITA Learning Content//EN" "learningContent.dtd">
-<learningContent id="content_rxt_zl5_vr">
+<learningContent id="content_rxt_zl5_vr1">
     <title>Concept topics</title>
     <prolog><author>Sharon Burton</author>
         <author href="http://www.scriptorium.com"  scope="external" format="html">Sarah O’Keefe, Scriptorium</author>

--- a/topics/lc_dita_intro.dita
+++ b/topics/lc_dita_intro.dita
@@ -3,7 +3,7 @@
      github.com. See the accompanying LICENSE file for
      applicable licenses.-->
 <!DOCTYPE learningContent PUBLIC "-//OASIS//DTD DITA Learning Content//EN" "learningContent.dtd">
-<learningContent id="content_gxd_rry_5r">
+<learningContent id="content_gxd_rry_5r1">
     <title>What is DITA?</title>
     <shortdesc/>
     <learningContentbody>

--- a/topics/links/lc_conrefs.dita
+++ b/topics/links/lc_conrefs.dita
@@ -3,7 +3,7 @@
      github.com. See the accompanying LICENSE file for
      applicable licenses.-->
 <!DOCTYPE learningContent PUBLIC "-//OASIS//DTD DITA Learning Content//EN" "learningContent.dtd">
-<learningContent id="links">
+<learningContent id="links1">
     <title>conrefs</title>
     <prolog>
         <author>Sharon Burton</author>

--- a/topics/links/lc_relationships.dita
+++ b/topics/links/lc_relationships.dita
@@ -3,7 +3,7 @@
      github.com. See the accompanying LICENSE file for
      applicable licenses.-->
 <!DOCTYPE learningContent PUBLIC "-//OASIS//DTD DITA Learning Content//EN" "learningContent.dtd">
-<learningContent id="links">
+<learningContent id="links2">
     <title>Relationship tables</title>
     <prolog>
         <author>Sharon Burton</author>

--- a/topics/metadata/lc_md_definition.dita
+++ b/topics/metadata/lc_md_definition.dita
@@ -3,7 +3,7 @@
      github.com. See the accompanying LICENSE file for
      applicable licenses.-->
 <!DOCTYPE learningContent PUBLIC "-//OASIS//DTD DITA Learning Content//EN" "learningContent.dtd">
-<learningContent id="content_rxt_zl5_vr">
+<learningContent id="content_rxt_zl5_vr2">
     <title>What is metadata?</title>
     <prolog>
         <author href="http://www.scriptorium.com" scope="external" format="html">Sarah O’Keefe,

--- a/topics/metadata/lc_md_use.dita
+++ b/topics/metadata/lc_md_use.dita
@@ -3,7 +3,7 @@
      github.com. See the accompanying LICENSE file for
      applicable licenses.-->
 <!DOCTYPE learningContent PUBLIC "-//OASIS//DTD DITA Learning Content//EN" "learningContent.dtd">
-<learningContent id="content_rxt_zl5_vr">
+<learningContent id="content_rxt_zl5_vr3">
     <title>How do you use metadata?</title>
     <prolog>
         <author href="http://www.scriptorium.com" scope="external" format="html">Sarah O’Keefe,

--- a/topics/metadata/lc_metadata.dita
+++ b/topics/metadata/lc_metadata.dita
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?> <!-- This file is part of the DITA Training project hosted on       github.com. See the accompanying LICENSE file for       applicable licenses.-->
 <!DOCTYPE learningContent PUBLIC "-//OASIS//DTD DITA Learning Content//EN" "learningContent.dtd">
-<learningContent id="content_gxd_rry_5r">
+<learningContent id="content_gxd_rry_5r2">
     <title>Metadata</title>
     <prolog>
         <author href="http://www.scriptorium.com"  scope="external" format="html">Sarah O’Keefe, Scriptorium</author>

--- a/topics/tables/lc_best_practices.dita
+++ b/topics/tables/lc_best_practices.dita
@@ -6,18 +6,18 @@
     <learningContentbody>
         <lcInstruction><p>Always wrap content in the table in &lt;p> tags. Forgetting this can
                 result in the content of the table to format in unexpected ways. </p><p>While the
-                DITA specification allows you to nest tables, it's a Bad Idea™.
-                </p><p>Whenever possible, consider organizing the content in your table to include
-                more rows instead of more columns. When you send the content to an output,
-                pagination issues can make many columns appear in unexpected ways. </p><p>In many
-                word processing tools, people use tables to visually format content such as indented
-                lists. In DITA, this is not done and can lead to unexpected results. </p><p>Consider
-                localization text expansion in tables. Where possible, design the content for up to
-                40% text expansion. </p><p>The DITA standard allows graphics table cells. In
-                practice, it's best to place just small icons in table cells. </p>Consider the
-            possible outputs when you create tables. Table rendering may very different be on a
-            small screen, such as a mobile device. <p>Consider using non-tables and rendering as
-                table on big screen or big paper. For example: definition lists, which can be
-                rendered as either a table or as a hanging indent (default)</p></lcInstruction>
+                DITA specification allows you to nest tables, it's a Bad Idea™. </p><p>Whenever
+                possible, consider organizing the content in your table to include more rows instead
+                of more columns. When you send the content to an output, pagination issues can make
+                many columns appear in unexpected ways. </p><p>In many word processing tools, people
+                use tables to visually format content such as indented lists. In DITA, this is not
+                done and can lead to unexpected results. </p><p>Consider localization text expansion
+                in tables. Where possible, design the content for up to 40% text expansion.
+                </p><p>The DITA standard allows graphics table cells. In practice, it's best to
+                place just small icons in table cells. </p>Consider the possible outputs when you
+            create tables. Table rendering may very different be on a small screen, such as a mobile
+            device. <p>Consider using non-tables and rendering as table on big screen or big paper.
+                For example: definition lists, which can be rendered as either a table or as a
+                hanging indent (default)</p></lcInstruction>
     </learningContentbody>
 </learningContent>


### PR DESCRIPTION
Make them unique by adding a suffix 1,2,..., 9, a,b.
This is not a DITA requirement but these IDs may be used in some cases - for example we use the topic IDs for providing contextual help and in that case they should be unique.
