### PR TITLE
Modifying assessment metadata

### DIFF
--- a/maps/m_links.ditamap
+++ b/maps/m_links.ditamap
@@ -13,7 +13,11 @@
   <topicref href="../topics/links/lc_xrefs.dita"/>
   <topicref href="../topics/links/lc_links.dita"/>
   <topicref href="../topics/links/lc_relationships.dita"/>
-  <topichead navtitle="Assessments">
+  <!-- The type="assessments" is necessary for the transform that loads assessments into LearnDashLMS. -->
+  <topichead type="assessments">
+   <topicmeta>
+    <navtitle>Assessments</navtitle>
+   </topicmeta>
    <topicref href="../assessments/links/lca_xref.dita"/>
    <topicref href="../assessments/links/lca_relationships.dita"/>
    <topicref href="../assessments/links/lca_weblink.dita"/>

--- a/maps/m_metadata.ditamap
+++ b/maps/m_metadata.ditamap
@@ -8,7 +8,11 @@
  <topicref href="../topics/metadata/lc_metadata.dita">
   <topicref href="../topics/metadata/lc_md_definition.dita"/>
   <topicref href="../topics/metadata/lc_md_use.dita"/>
-  <topichead navtitle="Assessments">
+  <!-- The type="assessments" is necessary for the transform that loads assessments into LearnDashLMS. -->
+  <topichead type="assessments">
+   <topicmeta>
+    <navtitle>Assessments</navtitle>
+   </topicmeta>
    <topicref href="../assessments/metadata/lca_author.dita"/>
    <topicref href="../assessments/metadata/lca_definition.dita"/>
    <topicref href="../assessments/metadata/lca_filters.dita"/>

--- a/maps/m_tables.ditamap
+++ b/maps/m_tables.ditamap
@@ -8,7 +8,11 @@
         <topicref href="../topics/tables/lc_table_simple.dita"/>
         <topicref href="../topics/tables/lc_table_cals.dita"/>
         <topicref href="../topics/tables/lc_best_practices.dita"/>
-        <topichead navtitle="Assessments">
+        <!-- The type="assessments" is necessary for the transform that loads assessments into LearnDashLMS. -->
+        <topichead type="assessments">
+            <topicmeta>
+                <navtitle>Assessments</navtitle>
+            </topicmeta>
             <topicref href="../assessments/tables/lca_calselements.dita"/>
             <topicref href="../assessments/tables/lca_stelements.dita"/>
             <topicref href="../assessments/tables/lca_tableelements.dita"/>

--- a/maps/m_topics.ditamap
+++ b/maps/m_topics.ditamap
@@ -11,7 +11,11 @@
   <topicref href="../topics/lc_gloss.dita"/>
   <topicref href="../topics/lc_constraints.dita"/>
   <topicref href="../topics/lc_specialization.dita"/>
-  <topichead navtitle="Assessments">
+  <!-- The type="assessments" is necessary for the transform that loads assessments into LearnDashLMS. -->
+  <topichead type="assessments">
+   <topicmeta>
+    <navtitle>Assessments</navtitle>
+   </topicmeta>
    <topicref href="../assessments/lca_elementtopic.dita"/>
    <topicref href="../assessments/lca_questions.dita"/>
    <topicref href="../assessments/lca_concept.dita"/>

--- a/maps/m_what_is_dita.ditamap
+++ b/maps/m_what_is_dita.ditamap
@@ -8,7 +8,11 @@
   <topicref href="../topics/lc_markup.dita"/>
   <topicref href="../topics/lc_structure.dita"/>
   <topicref href="../topics/lc_topic.dita"/>
-  <topichead navtitle="Assessments">
+  <!-- The type="assessments" is necessary for the transform that loads assessments into LearnDashLMS. -->
+  <topichead type="assessments">
+   <topicmeta>
+    <navtitle>Assessments</navtitle>
+   </topicmeta>
    <topicref href="../assessments/lca_validtopic.dita"/>
    <topicref href="../assessments/lca_topicscope.dita"/>
    <topicref href="../assessments/lca_htmldita.dita"/>


### PR DESCRIPTION
Moved navtitle to topicmeta; added type=“assessment” for OT processing.
