### PR TITLE
Issue 258: Fix path to plugins folder

### DIFF
--- a/en-us/course08-publishing_output/topics/lc_install_custom_plugin.dita
+++ b/en-us/course08-publishing_output/topics/lc_install_custom_plugin.dita
@@ -34,7 +34,7 @@
             <steps id="steps_ezx_ztg_2z">
                 <step>
                     <cmd>Locate the zip file <b>com.learningdita.ld_xhtml.zip</b> in the
-                            <b>samples/plugin</b> folder you downloaded at the beginning of this
+                            <b>samples/plugins</b> folder you downloaded at the beginning of this
                         course.</cmd>
                 </step>
                 <step>


### PR DESCRIPTION
Correct the path in step 1 of the Installing a custom plugin topic (lc_install_custom_plugin.dita). Should be samples/plugins instead of samples/plugin.