### PR TITLE
Issue 256: Fix website reference

### DIFF
--- a/en-us/course08-publishing_output/topics/lc_installing_the_dita_ot.dita
+++ b/en-us/course08-publishing_output/topics/lc_installing_the_dita_ot.dita
@@ -34,7 +34,7 @@
         <taskbody>
             <steps id="steps_h3y_3nw_cz">
                 <step>
-                    <cmd>In a web browser, go to the DITA OT SourceForge website (<xref
+                    <cmd>In a web browser, go to the DITA Open Toolkit website (<xref
                             href="http://www.dita-ot.org/" format="html" scope="external"/>), where
                         the open source DITA OT is available.</cmd>
                 </step>


### PR DESCRIPTION
In lc_installing_the_dita_ot.dita it refers to the 'DITA OT SourceForge
website'. This should just refer to the 'DITA Open Toolkit website'.