### PR TITLE
Cleanup - pick # text removed from assessment. Links updated

### DIFF
--- a/DITA-1.3/en-us/Learning_and_training_specialization/assessments/learning_maps/lca_group-name.dita
+++ b/DITA-1.3/en-us/Learning_and_training_specialization/assessments/learning_maps/lca_group-name.dita
@@ -11,19 +11,19 @@
     </prolog>
     <learningAssessmentbody>
         <lcInteraction>
-            <lcTrueFalse id="t-f_group-naming">
-                <lcQuestion>Which element allows you to name a learning group?</lcQuestion>
-                <lcAnswerOptionGroup>
-                    <lcAnswerOption>
-                        <lcAnswerContent>&lt;title/></lcAnswerContent>
-                        <lcCorrectResponse/>
-                    </lcAnswerOption>
-                    <lcAnswerOption>
-                        <lcAnswerContent>&lt;navtitle/></lcAnswerContent>
-                    </lcAnswerOption>
-                </lcAnswerOptionGroup>
-                <lcFeedbackIncorrect>The &lt;title> element allows you to name a learning group.</lcFeedbackIncorrect>
-            </lcTrueFalse>
+            <lcSingleSelect2 id="ss_group-naming">
+                <lcQuestion2>Which element allows you to name a learning group?</lcQuestion2>
+                <lcAnswerOptionGroup2>
+                    <lcAnswerOption2>
+                        <lcAnswerContent2>&lt;title/></lcAnswerContent2>
+                        <lcCorrectResponse2/>
+                    </lcAnswerOption2>
+                    <lcAnswerOption2>
+                        <lcAnswerContent2>&lt;navtitle/></lcAnswerContent2>
+                    </lcAnswerOption2>
+                </lcAnswerOptionGroup2>
+                <lcFeedbackIncorrect2>The &lt;title> element allows you to name a learning group.</lcFeedbackIncorrect2>
+            </lcSingleSelect2>
         </lcInteraction>
     </learningAssessmentbody>
 </learningAssessment>

--- a/DITA-1.3/en-us/Learning_and_training_specialization/assessments/learning_maps/lca_object-name.dita
+++ b/DITA-1.3/en-us/Learning_and_training_specialization/assessments/learning_maps/lca_object-name.dita
@@ -11,18 +11,18 @@
     </prolog>
     <learningAssessmentbody>
         <lcInteraction>
-            <lcTrueFalse id="t-f_object-naming">
-                <lcQuestion>Which element allows you to name a learning object?</lcQuestion>
-                <lcAnswerOptionGroup>
-                    <lcAnswerOption>
-                        <lcAnswerContent>&lt;title/></lcAnswerContent>
-                    </lcAnswerOption>
-                    <lcAnswerOption>
-                        <lcAnswerContent>&lt;navtitle/></lcAnswerContent>
-                        <lcCorrectResponse/>
-                    </lcAnswerOption>
-                </lcAnswerOptionGroup>
-            </lcTrueFalse>
+            <lcSingleSelect2 id="ss_object-naming">
+                <lcQuestion2>Which element allows you to name a learning object?</lcQuestion2>
+                <lcAnswerOptionGroup2>
+                    <lcAnswerOption2>
+                        <lcAnswerContent2>&lt;title/></lcAnswerContent2>
+                    </lcAnswerOption2>
+                    <lcAnswerOption2>
+                        <lcAnswerContent2>&lt;navtitle/></lcAnswerContent2>
+                        <lcCorrectResponse2/>
+                    </lcAnswerOption2>
+                </lcAnswerOptionGroup2>
+            </lcSingleSelect2>
         </lcInteraction>
         
     </learningAssessmentbody>

--- a/DITA-1.3/en-us/Learning_and_training_specialization/samples/la_l1_t1_spoilage.dita
+++ b/DITA-1.3/en-us/Learning_and_training_specialization/samples/la_l1_t1_spoilage.dita
@@ -6,7 +6,7 @@
     <learningAssessmentbody>
         <lcInteraction id="lcInteraction_lk2_qws_rcb">
             <lcTrueFalse2>
-                <lcQuestion2>Moldy food is safe to give to your flock (true/false)</lcQuestion2>
+                <lcQuestion2>Moldy food is safe to give to your flock. </lcQuestion2>
                 <lcAnswerOptionGroup2 id="lcAnswerOptionGroup2_zhf_rws_rcb">
                     <lcAnswerOption2>
                         <lcAnswerContent2>True</lcAnswerContent2>

--- a/DITA-1.3/en-us/Learning_and_training_specialization/samples/la_l1_t1_storage.dita
+++ b/DITA-1.3/en-us/Learning_and_training_specialization/samples/la_l1_t1_storage.dita
@@ -6,7 +6,7 @@
     <learningAssessmentbody>
         <lcInteraction id="lcInteraction_vwh_lws_rcb">
             <lcTrueFalse2>
-                <lcQuestion2>Feed must be stored away from insects (true/false)</lcQuestion2>
+                <lcQuestion2>Feed must be stored away from insects.</lcQuestion2>
                 <lcAnswerOptionGroup2 id="lcAnswerOptionGroup2_gzr_lws_rcb">
                     <lcAnswerOption2>
                         <lcAnswerContent2>True</lcAnswerContent2>

--- a/DITA-1.3/en-us/Learning_and_training_specialization/samples/la_l3_t1_height2.dita
+++ b/DITA-1.3/en-us/Learning_and_training_specialization/samples/la_l3_t1_height2.dita
@@ -6,7 +6,7 @@
     <learningAssessmentbody>
         <lcInteraction id="lcInteraction_x24_dg1_scb">
             <lcTrueFalse2>
-                <lcQuestion2>The feeder pan height should be even with the back of an average duck (true or false)?</lcQuestion2>
+                <lcQuestion2>The feeder pan height should be even with the back of an average duck?</lcQuestion2>
                 <lcAnswerOptionGroup2 id="lcAnswerOptionGroup2_y31_2g1_scb">
                     <lcAnswerOption2>
                         <lcAnswerContent2>True</lcAnswerContent2>

--- a/DITA-1.3/en-us/course02-authoring_concepts/topics/lc_images.dita
+++ b/DITA-1.3/en-us/course02-authoring_concepts/topics/lc_images.dita
@@ -59,9 +59,7 @@
    &lt;/conbody>
 &lt;/concept></pre>
                     </stepxmp>
-                    <info>(Sample image source: <xref
-                            href="https://www.flickr.com/photos/robin1966/17023058470/in/photolist-rWgCd7-cmRK8u-9xVaxC-6gd5eJ-cmfJ5b-uWNaXd-otWNCc-uVT475-sMHAM3-9GKwiQ-6JKXJ2-82AHGf-hcZ8bP-7ZTsaQ-86yGNs-8fhwwj-cNBfgS-dHFgu4-uUW4LP-9LoRo5-9UDfm4-kxadgx-dE2sWn-n81ps-ekxvX6-9CbYgZ-9Viusx-vSQBdJ-2NanU-hnHyuZ-ccgxVs-9EhZaA-771RiR-878qcy-p1VysW-c7uSpG-ekDh7N-7xy72F-9EdriM-4U5pCv-uB8dho-9U5TSR-nN8BUB-n94kcF-brM2oC-7xeNDk-a85HG5-31beq8-c1Mh7A-cCVXxA"
-                            format="html" scope="external">Flickr, Micolo J</xref>)</info>
+                    <info>(Sample image source: Flickr, Micolo J.)</info>
                     <info>The &lt;image> element you added contains a link (href) to the location of
                         the image file. A link inside an &lt;image> element can point to the
                         filepath for an image on a server or to a web link for an image.</info>
@@ -84,9 +82,7 @@
    &lt;/conbody>
 &lt;/concept></pre>
                     </stepxmp>
-                    <info>(Sample image source: <xref
-                            href="https://www.flickr.com/photos/24874528@N04/3453886876/in/photolist-6gd5eJ-cmfJ5b-uWNaXd-otWNCc-uVT475-sMHAM3-9GKwiQ-6JKXJ2-82AHGf-hcZ8bP-7ZTsaQ-86yGNs-8fhwwj-cNBfgS-dHFgu4-uUW4LP-9LoRo5-9UDfm4-kxadgx-dE2sWn-n81ps-ekxvX6-9CbYgZ-9Viusx-vSQBdJ-2NanU-hnHyuZ-ccgxVs-9EhZaA-771RiR-878qcy-p1VysW-c7uSpG-ekDh7N-7xy72F-9EdriM-4U5pCv-uB8dho-9U5TSR-nN8BUB-n94kcF-brM2oC-7xeNDk-a85HG5-31beq8-c1Mh7A-cCVXxA-2NaAm-9CWzqD-9ZfMhv"
-                            format="html" scope="external">Flickr, Airwolfhound</xref>)</info>
+                    <info>(Sample image source: Flickr, Airwolfhound)</info>
                     <info>The &lt;fig> element is another way to add an image to a concept
                         topic.</info>
                     <info>The &lt;fig> element you added contains a &lt;title> element and an

--- a/DITA-1.3/en-us/course03-authoring_tasks/assessments/finishing/lca_elements.dita
+++ b/DITA-1.3/en-us/course03-authoring_tasks/assessments/finishing/lca_elements.dita
@@ -16,7 +16,7 @@
   <lcInteraction>
    <lcSingleSelect id="lcSingleSelect_eh4_bbb_dt">
     <lcQuestion>Where can the &lt;result>, &lt;example>, and &lt;postreq> elements appear in a
-     strict task? (pick one)</lcQuestion>
+     strict task?</lcQuestion>
     <lcAnswerOptionGroup id="lcAnswerOptionGroup_fh4_bbb_dt">
      <lcAnswerOption>
       <lcAnswerContent>Before the &lt;steps> element</lcAnswerContent>

--- a/DITA-1.3/en-us/course03-authoring_tasks/assessments/finishing/lca_postreq.dita
+++ b/DITA-1.3/en-us/course03-authoring_tasks/assessments/finishing/lca_postreq.dita
@@ -15,7 +15,7 @@
  <learningAssessmentbody>
   <lcInteraction>
    <lcSingleSelect id="lcSingleSelect_eh4_bbb_dt">
-    <lcQuestion>What is the main purpose of the &lt;postreq> element? (pick one)</lcQuestion>
+    <lcQuestion>What is the main purpose of the &lt;postreq> element?</lcQuestion>
     <lcAnswerOptionGroup id="lcAnswerOptionGroup_fh4_bbb_dt">
      <lcAnswerOption>
       <lcAnswerContent>To tell the reader what to do next.</lcAnswerContent>

--- a/DITA-1.3/en-us/course03-authoring_tasks/assessments/steps/lca_choices.dita
+++ b/DITA-1.3/en-us/course03-authoring_tasks/assessments/steps/lca_choices.dita
@@ -15,8 +15,7 @@
  <learningAssessmentbody>
   <lcInteraction>
    <lcSingleSelect id="single_select_choices">
-    <lcQuestion>When would it make the most sense to use the &lt;choices> element? (pick
-     one)</lcQuestion>
+    <lcQuestion>When would it make the most sense to use the &lt;choices> element?</lcQuestion>
     <lcAnswerOptionGroup id="lcAnswerOptionGroup_mpk_w5b_kt">
      <lcAnswerOption>
       <lcAnswerContent>When the choices are very complex.</lcAnswerContent>


### PR DESCRIPTION
Fixed true/false vs. Single select issue for learning maps topics.
Removed "pick one" in sample topics in L&T for single select  
Removed "pick one" text from assessments in course 3 
Removed flickr links